### PR TITLE
Fixes #7: PR previews on GitHub Pages

### DIFF
--- a/.github/workflows/build-root-index.yml
+++ b/.github/workflows/build-root-index.yml
@@ -10,6 +10,8 @@ name: Build root index
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "pr-preview/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr_preview_pages.yml
+++ b/.github/workflows/pr_preview_pages.yml
@@ -1,0 +1,46 @@
+# Serves the PR branch as a static snapshot under /pr-preview/pr-<number>/ on GitHub Pages.
+# GitHub Actions cannot keep a real HTTP server running until merge; this is the standard substitute.
+# Previews are removed when the PR is closed (including merge). Requires Pages "Deploy from branch"
+# (this repo uses main) and Actions workflow read/write permission.
+#
+# Fork PRs: not supported by rossjrw/pr-preview-action v1.
+
+name: PR preview on Pages
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+concurrency:
+  group: pages-pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  pr-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR snapshot
+        if: github.event.action != 'closed'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout main (cleanup on PR close)
+        if: github.event.action == 'closed'
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Deploy or remove preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: .
+          preview-branch: main
+          umbrella-dir: pr-preview
+          action: auto
+          qr-code: false
+          wait-for-pages-deployment: true

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -17,7 +17,7 @@ This repo is the **public** GitHub Pages site. Subsite content and pill labels a
    - Push content into **this** repo under a folder named **like the repo** (e.g. `discogs-collection/`).  
    - Do **not** overwrite this repo’s root `index.html`; only add/update its own subfolder.
 
-2. **Sync workflow** (e.g. `sync-variables-pages-repo.yml`)  
+2. **Sync workflow** (e.g. `sync_variables_to_pages.yml` in the private repo)  
    - Runs on schedule and/or `workflow_dispatch`.  
    - Reads the private repo’s pill label (e.g. variable `PAGES_SUBPATH_LABEL`).  
    - Calls the GitHub API to create/update **this** repo’s variable `{repo_name}_PILL_LABEL`.  
@@ -28,7 +28,12 @@ This repo is the **public** GitHub Pages site. Subsite content and pill labels a
 
 - **Build root index** (`.github/workflows/build-root-index.yml`)  
   Runs on push to `main` and on `workflow_dispatch`. Reads `PRIVATE_REPOS` and each `{repo}_PILL_LABEL`, generates `index.html`, and commits and pushes if changed. So when a private repo pushes subsite content, the push triggers this and the root nav stays in sync with variables.  
-  **Optional secret:** `BUILD_VARIABLES_TOKEN` — a PAT with **repo** scope so the workflow can read repository variables via the API (the default `GITHUB_TOKEN` often gets 403). If unset, pill labels fall back to the repo name.
+  **Optional secret:** `BUILD_VARIABLES_TOKEN` — a PAT with **repo** scope so the workflow can read repository variables via the API (the default `GITHUB_TOKEN` often gets 403). If unset, pill labels fall back to the repo name.  
+  Pushes that **only** change `pr-preview/**` (PR preview deploy/cleanup) are ignored so this workflow does not fight the preview action.
+
+- **PR preview on Pages** (`.github/workflows/pr_preview_pages.yml`)  
+  On each pull request (open / sync / reopen), publishes the **repository root** of the PR head under `https://<owner>.github.io/pr-preview/pr-<number>/` (user-site layout; see comment on the PR from the action). On **close** (merged or not), removes that folder from `main`. This replaces a long-lived “local server” on a runner, which GitHub Actions does not support across the PR lifetime.  
+  **Settings:** **Actions → General → Workflow permissions** must allow **Read and write**. **Pages** must use **Deploy from a branch** (this site uses `main` / root). Previews from **forks** are not supported by the action (v1).
 
 ## Adding a new private subsite
 


### PR DESCRIPTION
## Summary
- New workflow `pr_preview_pages.yml`: on PR open/sync/reopen, deploys the repo root (PR head, checkout by SHA) to `pr-preview/pr-<N>/` on `main`; on PR close (merge or not), removes that folder via `rossjrw/pr-preview-action@v1`.
- `build-root-index.yml`: `paths-ignore: pr-preview/**` on push so preview-only commits do not re-run the root index builder.

## Why not a literal local server?
GitHub Actions runners end when the job finishes; they cannot host a process until the PR merges. Pages PR preview is the usual pattern.

## Repo settings (manual)
- **Settings → Actions → General → Workflow permissions:** Read and write.
- **Settings → Pages:** Deploy from branch `main` (required by pr-preview-action v1; not `GitHub Actions`-only source per upstream docs).

Fork PRs are not supported by the action (v1).

Made with [Cursor](https://cursor.com)