### PR TITLE
Revise DEPLOY.md for subsite deploy contract

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,6 +1,15 @@
 # Deploy: how private repos connect to this Pages site
 
-This repo is the **public** GitHub Pages site. Private subsite repos push built content here; **Build root index** turns that into the root `index.html`, nav links, and pill styling (via each subsite’s `design-tokens.json` when present).
+This repo is the **public** user site (`username.github.io`). Subsite folders and workflows publish the **root** `https://<username>.github.io/` and paths like `/<subsite>/`.
+
+## GitHub Pages on this repo
+
+In **Settings → Pages**:
+
+- **Source:** Deploy from a branch.
+- **Branch:** `main`, folder **/** (repository root).
+
+Everything in `main` at the repo root is what Pages serves. Private subsite repos push into **named subfolders** here (not the root `index.html`); **Build root index** regenerates that root `index.html` from `PRIVATE_REPOS` and each subsite’s `design-tokens.json`.
 
 ## What each private repo should do
 
@@ -17,30 +26,30 @@ Every subsite lives in its **own** private repo. That repo is responsible for tw
    - It ensures **`PRIVATE_REPOS`** on this repo includes your repo’s name (read → add if missing → write).  
    - It uses **`PAGES_DEPLOY_TOKEN`**: a PAT with **Actions variables** read/write on **this** repo, plus permission to push contents for deploy.
 
-Together, deploy brings the files; sync makes **Build root index** know to list your folder.
+Deploy brings the files; sync makes **Build root index** include your folder in the variable list.
 
 ---
 
 ## Repository variable: `PRIVATE_REPOS`
 
-Comma-separated list of private repo **names** that are subsites (e.g. `discogs-collection,album-scraper`). **Build root index** uses it to know which subfolders to include in the root index.
+Comma-separated list of private repo **names** that are subsites (e.g. `discogs-collection,album-scraper`). **Build root index** uses it to know which subfolders get nav pills on the root page.
 
 ## `design-tokens.json` (per subsite)
 
-Each name in `PRIVATE_REPOS` should have a folder `<repo-name>/` with at least `index.html`. For nav, **Build root index** reads `<repo-name>/design-tokens.json` if present:
+For each name in `PRIVATE_REPOS`, expect a folder `<repo-name>/` with at least `index.html`. For labels and pill CSS, **Build root index** reads `<repo-name>/design-tokens.json` if present:
 
-- **`pill.label`** — text on the root project pill. If missing or empty, the workflow uses the **subpath uppercased** (e.g. `discogs-collection` → `DISCOGS-COLLECTION`).  
-- **`pill.background`**, **`pill.border`**, **`pill.text`**, and hover fields — optional; default orchid/slate pill styles apply when omitted.
+- **`pill.label`** — nav pill text. If missing or empty, the workflow uppercases the folder name (e.g. `discogs-collection` → `DISCOGS-COLLECTION`).  
+- **`pill.background`**, **`pill.border`**, **`pill.text`** — optional.  
+- **Hover:** `pill.hover_background`, `pill.hover_text`, `pill.hover_border`, `pill.hover_shadow` — optional; default orchid/slate styling applies when omitted.
 
-Private repos typically generate this file as part of deploy.
+Private repos usually generate this file during deploy.
 
 ## Workflows in this repo
 
 - **Build root index** (`.github/workflows/build-root-index.yml`)  
-  Runs on push to `main` and on `workflow_dispatch`. Reads `PRIVATE_REPOS`, loads each subsite’s `design-tokens.json` for labels and pill CSS, writes `index.html`, and commits and pushes if changed.  
-  **Optional secret:** `BUILD_VARIABLES_TOKEN` — PAT with **repo** scope if `gh variable list` needs it to read `PRIVATE_REPOS`.  
-  Pushes that **only** change `pr-preview/**` are ignored so this workflow does not fight the preview action.
+  - **When:** push to `main` (except commits that only touch `pr-preview/**`) and `workflow_dispatch`.  
+  - **What:** Reads `PRIVATE_REPOS` from the job (`vars.PRIVATE_REPOS`). If that is empty, falls back to `gh variable list` with the workflow token. For each listed repo, loads `<repo>/design-tokens.json` if present, writes root `index.html`, and commits only if it changed.
 
 - **PR preview on Pages** (`.github/workflows/pr_preview_pages.yml`)  
-  On each pull request (open / sync / reopen), publishes the **repository root** of the PR head under `https://<owner>.github.io/pr-preview/pr-<number>/` (user-site layout; see the comment on the PR from the action). On **close** (merged or not), removes that folder from `main`.  
-  **Settings:** **Actions → General → Workflow permissions** must allow **Read and write**. **Pages** must use **Deploy from a branch** (this site uses `main` / root). Previews from **forks** are not supported by the action (v1).
+  Uses [rossjrw/pr-preview-action](https://github.com/rossjrw/pr-preview-action) to put the PR head’s repo root under `/pr-preview/pr-<number>/` on the **same** `main` Pages deployment (see the bot comment on the PR for the preview URL). On PR close, removes that folder from `main`.  
+  **Requirements:** **Actions → General → Workflow permissions** → **Read and write** for `contents` (and `pull-requests` for the action). Same Pages branch/root settings as above. Previews from **fork** PRs are not supported (v1).

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,15 +1,6 @@
 # Deploy: how private repos connect to this Pages site
 
-This repo is the **public** user site (`username.github.io`). Subsite folders and workflows publish the **root** `https://<username>.github.io/` and paths like `/<subsite>/`.
-
-## GitHub Pages on this repo
-
-In **Settings → Pages**:
-
-- **Source:** Deploy from a branch.
-- **Branch:** `main`, folder **/** (repository root).
-
-Everything in `main` at the repo root is what Pages serves. Private subsite repos push into **named subfolders** here (not the root `index.html`); **Build root index** regenerates that root `index.html` from `PRIVATE_REPOS` and each subsite’s `design-tokens.json`.
+This repo is the **public** GitHub Pages site. Private subsite repos push built content here; **Build root index** turns that into the root `index.html`, nav links, and pill styling (via each subsite’s `design-tokens.json` when present).
 
 ## What each private repo should do
 
@@ -26,30 +17,30 @@ Every subsite lives in its **own** private repo. That repo is responsible for tw
    - It ensures **`PRIVATE_REPOS`** on this repo includes your repo’s name (read → add if missing → write).  
    - It uses **`PAGES_DEPLOY_TOKEN`**: a PAT with **Actions variables** read/write on **this** repo, plus permission to push contents for deploy.
 
-Deploy brings the files; sync makes **Build root index** include your folder in the variable list.
+Together, deploy brings the files; sync makes **Build root index** know to list your folder.
 
 ---
 
 ## Repository variable: `PRIVATE_REPOS`
 
-Comma-separated list of private repo **names** that are subsites (e.g. `discogs-collection,album-scraper`). **Build root index** uses it to know which subfolders get nav pills on the root page.
+Comma-separated list of private repo **names** that are subsites (e.g. `discogs-collection,album-scraper`). **Build root index** uses it to know which subfolders to include in the root index.
 
 ## `design-tokens.json` (per subsite)
 
-For each name in `PRIVATE_REPOS`, expect a folder `<repo-name>/` with at least `index.html`. For labels and pill CSS, **Build root index** reads `<repo-name>/design-tokens.json` if present:
+Each name in `PRIVATE_REPOS` should have a folder `<repo-name>/` with at least `index.html`. For nav, **Build root index** reads `<repo-name>/design-tokens.json` if present:
 
-- **`pill.label`** — nav pill text. If missing or empty, the workflow uppercases the folder name (e.g. `discogs-collection` → `DISCOGS-COLLECTION`).  
-- **`pill.background`**, **`pill.border`**, **`pill.text`** — optional.  
-- **Hover:** `pill.hover_background`, `pill.hover_text`, `pill.hover_border`, `pill.hover_shadow` — optional; default orchid/slate styling applies when omitted.
+- **`pill.label`** — text on the root project pill. If missing or empty, the workflow uses the **subpath uppercased** (e.g. `discogs-collection` → `DISCOGS-COLLECTION`).  
+- **`pill.background`**, **`pill.border`**, **`pill.text`**, and hover fields — optional; default orchid/slate pill styles apply when omitted.
 
-Private repos usually generate this file during deploy.
+Private repos typically generate this file as part of deploy.
 
 ## Workflows in this repo
 
 - **Build root index** (`.github/workflows/build-root-index.yml`)  
-  - **When:** push to `main` (except commits that only touch `pr-preview/**`) and `workflow_dispatch`.  
-  - **What:** Reads `PRIVATE_REPOS` from the job (`vars.PRIVATE_REPOS`). If that is empty, falls back to `gh variable list` with the workflow token. For each listed repo, loads `<repo>/design-tokens.json` if present, writes root `index.html`, and commits only if it changed.
+  Runs on push to `main` and on `workflow_dispatch`. Reads `PRIVATE_REPOS`, loads each subsite’s `design-tokens.json` for labels and pill CSS, writes `index.html`, and commits and pushes if changed.  
+  **Optional secret:** `BUILD_VARIABLES_TOKEN` — PAT with **repo** scope if `gh variable list` needs it to read `PRIVATE_REPOS`.  
+  Pushes that **only** change `pr-preview/**` are ignored so this workflow does not fight the preview action.
 
 - **PR preview on Pages** (`.github/workflows/pr_preview_pages.yml`)  
-  Uses [rossjrw/pr-preview-action](https://github.com/rossjrw/pr-preview-action) to put the PR head’s repo root under `/pr-preview/pr-<number>/` on the **same** `main` Pages deployment (see the bot comment on the PR for the preview URL). On PR close, removes that folder from `main`.  
-  **Requirements:** **Actions → General → Workflow permissions** → **Read and write** for `contents` (and `pull-requests` for the action). Same Pages branch/root settings as above. Previews from **fork** PRs are not supported (v1).
+  On each pull request (open / sync / reopen), publishes the **repository root** of the PR head under `https://<owner>.github.io/pr-preview/pr-<number>/` (user-site layout; see the comment on the PR from the action). On **close** (merged or not), removes that folder from `main`.  
+  **Settings:** **Actions → General → Workflow permissions** must allow **Read and write**. **Pages** must use **Deploy from a branch** (this site uses `main` / root). Previews from **forks** are not supported by the action (v1).

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,51 +1,46 @@
 # Deploy: how private repos connect to this Pages site
 
-This repo is the **public** GitHub Pages site. Subsite content, nav **pill labels**, and **pill styling** come from what each private repo publishes under its folder (especially `design-tokens.json`). This file describes the contract.
+This repo is the **public** GitHub Pages site. Private subsite repos push built content here; **Build root index** turns that into the root `index.html`, nav links, and pill styling (via each subsite’s `design-tokens.json` when present).
 
-## Variables in this repo (public)
+## What each private repo should do
 
-- **`PRIVATE_REPOS`**  
-  Comma-separated list of private repo **names** that are subsites (e.g. `discogs-collection,album-scraper`). The **Build root index** workflow reads this to know which subfolders exist in this repo. It does **not** use per-repo `*_PILL_LABEL` variables.
+Every subsite lives in its **own** private repo. That repo is responsible for two things:
 
-- **`design-tokens.json` (per subsite)**  
-  Each entry in `PRIVATE_REPOS` should have a folder `<repo-name>/` containing at least `index.html`. For nav links, **Build root index** reads `<repo-name>/design-tokens.json` if present:
-  - **`pill.label`** — text on the root project pill. If missing or empty, the workflow uses the **subpath uppercased** (e.g. `discogs-collection` → `DISCOGS-COLLECTION`).
-  - **`pill.background`**, **`pill.border`**, **`pill.text`**, hover fields — optional; default orchid/slate pill styles apply when omitted.
+1. **Deploy to this repo**  
+   - Build the site in CI.  
+   - Push the output into **this** repo under a folder named **like the private repo** (e.g. `discogs-collection/`).  
+   - Include **`design-tokens.json`** there if you want a custom nav pill label or colors (see below).  
+   - Do **not** overwrite this repo’s root `index.html`; only add or update your subfolder.
 
-  Private repos (e.g. Discogs collection) generate this file when they deploy.
+2. **Register the subsite on this repo**  
+   - A small **sync** workflow (e.g. `sync_variables_to_pages.yml` in the private repo) runs on a schedule and/or `workflow_dispatch`.  
+   - It ensures **`PRIVATE_REPOS`** on this repo includes your repo’s name (read → add if missing → write).  
+   - It uses **`PAGES_DEPLOY_TOKEN`**: a PAT with **Actions variables** read/write on **this** repo, plus permission to push contents for deploy.
 
-## What each private repo must do
+Together, deploy brings the files; sync makes **Build root index** know to list your folder.
 
-1. **Deploy workflow**  
-   - Build its site.  
-   - Push content into **this** repo under a folder named **like the repo** (e.g. `discogs-collection/`).  
-   - Include **`design-tokens.json`** in that folder if you want a custom pill label or styling.  
-   - Do **not** overwrite this repo’s root `index.html`; only add/update its own subfolder.
+---
 
-2. **Sync workflow** (e.g. `sync_variables_to_pages.yml` in the private repo)  
-   - Runs on schedule and/or `workflow_dispatch`.  
-   - Ensures this repo’s **`PRIVATE_REPOS`** includes that private repo’s name (read → add if missing → write).  
-   - It **does not** set `*_PILL_LABEL` variables (legacy).  
-   - Uses **`PAGES_DEPLOY_TOKEN`** (PAT with **Actions variables** read/write on **this** repo, plus contents push for deploy).
+## Repository variable: `PRIVATE_REPOS`
 
-## This repo’s workflows
+Comma-separated list of private repo **names** that are subsites (e.g. `discogs-collection,album-scraper`). **Build root index** uses it to know which subfolders to include in the root index.
+
+## `design-tokens.json` (per subsite)
+
+Each name in `PRIVATE_REPOS` should have a folder `<repo-name>/` with at least `index.html`. For nav, **Build root index** reads `<repo-name>/design-tokens.json` if present:
+
+- **`pill.label`** — text on the root project pill. If missing or empty, the workflow uses the **subpath uppercased** (e.g. `discogs-collection` → `DISCOGS-COLLECTION`).  
+- **`pill.background`**, **`pill.border`**, **`pill.text`**, and hover fields — optional; default orchid/slate pill styles apply when omitted.
+
+Private repos typically generate this file as part of deploy.
+
+## Workflows in this repo
 
 - **Build root index** (`.github/workflows/build-root-index.yml`)  
-  Runs on push to `main` and on `workflow_dispatch`. Reads `PRIVATE_REPOS`, loads each subsite’s `design-tokens.json` for nav labels and pill CSS, generates `index.html`, and commits and pushes if changed.  
-  **Optional secret:** `BUILD_VARIABLES_TOKEN` — PAT with **repo** scope if `gh variable list` needs it for `PRIVATE_REPOS`.  
+  Runs on push to `main` and on `workflow_dispatch`. Reads `PRIVATE_REPOS`, loads each subsite’s `design-tokens.json` for labels and pill CSS, writes `index.html`, and commits and pushes if changed.  
+  **Optional secret:** `BUILD_VARIABLES_TOKEN` — PAT with **repo** scope if `gh variable list` needs it to read `PRIVATE_REPOS`.  
   Pushes that **only** change `pr-preview/**` are ignored so this workflow does not fight the preview action.
 
 - **PR preview on Pages** (`.github/workflows/pr_preview_pages.yml`)  
-  On each pull request (open / sync / reopen), publishes the **repository root** of the PR head under `https://<owner>.github.io/pr-preview/pr-<number>/` (user-site layout; see comment on the PR from the action). On **close** (merged or not), removes that folder from `main`.  
+  On each pull request (open / sync / reopen), publishes the **repository root** of the PR head under `https://<owner>.github.io/pr-preview/pr-<number>/` (user-site layout; see the comment on the PR from the action). On **close** (merged or not), removes that folder from `main`.  
   **Settings:** **Actions → General → Workflow permissions** must allow **Read and write**. **Pages** must use **Deploy from a branch** (this site uses `main` / root). Previews from **forks** are not supported by the action (v1).
-
-## Adding a new private subsite
-
-1. In the new repo: add a deploy workflow that pushes its build output to this repo under a folder named like the repo (e.g. `my-new-app/`), including **`design-tokens.json`** with at least `pill.label` if you want a specific nav label.  
-2. In the new repo: add the sync workflow (copy from e.g. `discogs-collection`), set `PAGES_REPO` to your Pages repo, and use **`PAGES_DEPLOY_TOKEN`** (PAT: contents + Actions variables read/write on the Pages repo).  
-3. Run the sync workflow once. It will add the repo name to **`PRIVATE_REPOS`** here.  
-4. After the next **Build root index** run, the root page will list the new project.
-
-### Legacy GitHub variables
-
-Older setups used **`{repo}_PILL_LABEL`** Action variables on this repo. They are **no longer read** by Build root index. You can delete those variables after subsites publish `pill.label` in `design-tokens.json`.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,6 +1,6 @@
 # Deploy: how private repos connect to this Pages site
 
-This repo is the **public** GitHub Pages site. Private subsite repos push built content here; **Build root index** turns that into the root `index.html`, nav links, and pill styling (via each subsite’s `design-tokens.json` when present).
+This repo is the **public** GitHub Pages site. The doc has two parts: what **private subsite repos** must do, then what **this repo** uses to turn their folders into the root `index.html` and nav (via `PRIVATE_REPOS` and each subsite’s `design-tokens.json`).
 
 ## What each private repo should do
 
@@ -9,7 +9,7 @@ Every subsite lives in its **own** private repo. That repo is responsible for tw
 1. **Deploy to this repo**  
    - Build the site in CI.  
    - Push the output into **this** repo under a folder named **like the private repo** (e.g. `discogs-collection/`).  
-   - Include **`design-tokens.json`** there if you want a custom nav pill label or colors (see below).  
+   - Include **`design-tokens.json`** there if you want a custom nav pill label or colors (described under **How this repo builds the root page**).  
    - Do **not** overwrite this repo’s root `index.html`; only add or update your subfolder.
 
 2. **Register the subsite on this repo**  
@@ -19,13 +19,15 @@ Every subsite lives in its **own** private repo. That repo is responsible for tw
 
 Together, deploy brings the files; sync makes **Build root index** know to list your folder.
 
----
+## How this repo builds the root page
 
-## Repository variable: `PRIVATE_REPOS`
+Once **`main`** has the subsite folders and **`PRIVATE_REPOS`** is up to date, everything below is **on this public repo only**: the variable, the optional token file per folder, and the workflows that regenerate the landing page.
+
+### `PRIVATE_REPOS` (Actions variable)
 
 Comma-separated list of private repo **names** that are subsites (e.g. `discogs-collection,album-scraper`). **Build root index** uses it to know which subfolders to include in the root index.
 
-## `design-tokens.json` (per subsite)
+### `design-tokens.json` (per subsite folder)
 
 Each name in `PRIVATE_REPOS` should have a folder `<repo-name>/` with at least `index.html`. For nav, **Build root index** reads `<repo-name>/design-tokens.json` if present:
 
@@ -34,7 +36,7 @@ Each name in `PRIVATE_REPOS` should have a folder `<repo-name>/` with at least `
 
 Private repos typically generate this file as part of deploy.
 
-## Workflows in this repo
+### Workflows
 
 - **Build root index** (`.github/workflows/build-root-index.yml`)  
   Runs on push to `main` and on `workflow_dispatch`. Reads `PRIVATE_REPOS`, loads each subsite’s `design-tokens.json` for labels and pill CSS, writes `index.html`, and commits and pushes if changed.  


### PR DESCRIPTION
Closes #16

## Summary
- **Private repos first:** Document deploy (push subfolder + `design-tokens.json`) and sync (`PRIVATE_REPOS` + `PAGES_DEPLOY_TOKEN`) as the two jobs each subsite repo owns.
- **No legacy vars:** Remove `*_PILL_LABEL` and related migration notes.
- **Tighter structure:** Remove duplicate checklist copy; follow with `PRIVATE_REPOS`, `design-tokens.json`, and this repo’s workflows without explicit "basics/advanced" section labels.

Made with [Cursor](https://cursor.com)