### PR TITLE
Add README for GitHub repo homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# victor-onofrei.github.io
+
+[GitHub Pages](https://pages.github.com/) user site: a root landing page with links to subsites. Each subsite is built in a separate repository and deployed into a folder in this repo.
+
+**Site:** [victor-onofrei.github.io](https://victor-onofrei.github.io/)
+
+Deployment, repository variables, and GitHub Actions for the root index and subsites are documented in [**DEPLOY.md**](DEPLOY.md).


### PR DESCRIPTION
Closes #18

Adds a short `README.md`: describes this repo as the GitHub Pages user site with subsites deployed from other repositories, links the live URL, and points to `DEPLOY.md` for automation and deploy details.

Made with [Cursor](https://cursor.com)