### PR TITLE
Add gitignored artifacts/ for local OneDrive assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Local-only assets (e.g. design references, QR exports) kept in-repo on disk but not published to GitHub
+artifacts/


### PR DESCRIPTION
Adds a root `.gitignore` entry for `artifacts/` so local reference images (vinyl icon, QR exports, etc.) can live beside the repo without being committed to GitHub Pages.

Closes #28.

Made with [Cursor](https://cursor.com)